### PR TITLE
Fix missing WorldInfo import in GameScene

### DIFF
--- a/app/src/main/java/com/example/robotparkour/scene/GameScene.java
+++ b/app/src/main/java/com/example/robotparkour/scene/GameScene.java
@@ -15,6 +15,7 @@ import com.example.robotparkour.audio.WorldMusicLibrary;
 import com.example.robotparkour.core.Scene;
 import com.example.robotparkour.core.SceneManager;
 import com.example.robotparkour.core.SceneType;
+import com.example.robotparkour.core.WorldInfo;
 import com.example.robotparkour.entity.Coin;
 import com.example.robotparkour.entity.Flag;
 import com.example.robotparkour.entity.Robot;


### PR DESCRIPTION
## Summary
- add the missing `WorldInfo` import to `GameScene` so compilation can resolve the type

## Testing
- `./gradlew :app:compileDebugJavaWithJavac` *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6831190b883308dd60eb4fee40ac3