### PR TITLE
Remove references to missing duck control button

### DIFF
--- a/app/src/main/java/com/crobot/game/GameActivity.java
+++ b/app/src/main/java/com/crobot/game/GameActivity.java
@@ -76,7 +76,6 @@ public class GameActivity extends AppCompatActivity {
         View left = findViewById(R.id.button_left);
         View right = findViewById(R.id.button_right);
         View jump = findViewById(R.id.button_jump);
-        View duck = findViewById(R.id.button_duck);
 
         View.OnTouchListener listener = (view, motionEvent) -> {
             int id = view.getId();
@@ -86,8 +85,6 @@ public class GameActivity extends AppCompatActivity {
                 gameView.handleButtonTouch(GameView.Control.RIGHT, motionEvent);
             } else if (id == R.id.button_jump) {
                 gameView.handleButtonTouch(GameView.Control.JUMP, motionEvent);
-            } else if (id == R.id.button_duck) {
-                gameView.handleButtonTouch(GameView.Control.DUCK, motionEvent);
             }
             return true;
         };
@@ -95,7 +92,6 @@ public class GameActivity extends AppCompatActivity {
         left.setOnTouchListener(listener);
         right.setOnTouchListener(listener);
         jump.setOnTouchListener(listener);
-        duck.setOnTouchListener(listener);
     }
 
     private void loadLevel(int world, int stage) {


### PR DESCRIPTION
## Summary
- stop looking up a duck control button that is not present in the layout
- remove the unused duck control dispatch from the touch listener setup

## Testing
- `./gradlew app:compileDebugJavaWithJavac` *(fails: Android SDK is not available in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ca20f5a8833098a7e69aef4b29b8