### PR TITLE
Fix legacy level entity conversion access and slip deceleration

### DIFF
--- a/app/src/main/java/com/crobot/game/GameView.java
+++ b/app/src/main/java/com/crobot/game/GameView.java
@@ -156,6 +156,8 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
     private boolean duckPressed;
     private boolean playerRespawnedThisFrame;
 
+    private float previousVx;
+
     private float cameraX;
     private float cameraY;
     private float currentScale = 1f;
@@ -226,8 +228,8 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
         animationTimer = 0f;
         player.width = level.getTileWidth() * 0.82f;
         player.height = level.getTileHeight() * 1.65f;
-        float previousVx = player.vx;
         player.vx = 0f;
+        previousVx = 0f;
         player.vy = 0f;
         player.onGround = false;
         player.facingRight = true;
@@ -1079,6 +1081,7 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
         }
         playerRespawnedThisFrame = true;
         player.respawn();
+        previousVx = 0f;
         lastPlayerAction = PlayerAction.IDLE;
     }
 
@@ -1585,6 +1588,7 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
             action = PlayerAction.JUMP;
         }
         lastPlayerAction = action;
+        previousVx = player.vx;
     }
 
     private void applyPhysics(float deltaSeconds, @NonNull LevelModel level) {

--- a/app/src/main/java/com/example/robotparkour/level/LevelLibrary.java
+++ b/app/src/main/java/com/example/robotparkour/level/LevelLibrary.java
@@ -293,7 +293,7 @@ public final class LevelLibrary {
             }
         }
 
-        LevelModel.Entity toLevelEntity() {
+        public LevelModel.Entity toLevelEntity() {
             int pixelX = Math.round((tileX + offsetX) * TILE_SIZE);
             int pixelY = Math.round((tileY + offsetY) * TILE_SIZE);
             return new LevelModel.Entity(type, pixelX, pixelY, extras);


### PR DESCRIPTION
## Summary
- expose LevelLibrary.EntitySpec#toLevelEntity so legacy data can instantiate level entities
- track the player's previous horizontal velocity to support slip deceleration without undefined variables
- reset the stored velocity when binding levels or respawning

## Testing
- `./gradlew compileDebugJavaWithJavac` *(fails: Android SDK missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9cfcf286c833092d94366ac8c8d8d