### PR TITLE
Fix incompatible checked icon gravity attribute

### DIFF
--- a/app/src/main/res/layout/item_level_button.xml
+++ b/app/src/main/res/layout/item_level_button.xml
@@ -16,7 +16,6 @@
     app:iconGravity="textStart"
     app:iconPadding="12dp"
     app:iconTint="@android:color/white"
-    app:checkedIconGravity="textStart"
     app:rippleColor="@color/accent_blue"
     app:strokeColor="@color/accent_blue"
     app:strokeWidth="1dp"


### PR DESCRIPTION
## Summary
- remove the invalid checkedIconGravity usage from the level button layout to restore resource processing

## Testing
- ⚠️ ./gradlew :app:assembleDebug (fails: Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9e18b05c083308c603f6af2808c6a