### PR TITLE
Fix MaterialButton checked icon gravity mismatch

### DIFF
--- a/app/src/main/res/layout/item_level_button.xml
+++ b/app/src/main/res/layout/item_level_button.xml
@@ -16,6 +16,7 @@
     app:iconGravity="textStart"
     app:iconPadding="12dp"
     app:iconTint="@android:color/white"
+    app:checkedIconGravity="TOP_END"
     app:rippleColor="@color/accent_blue"
     app:strokeColor="@color/accent_blue"
     app:strokeWidth="1dp"


### PR DESCRIPTION
## Summary
- set the level selection MaterialButton's checked icon gravity to a supported value to fix resource linking

## Testing
- ./gradlew :app:processDebugResources *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e3188c248330adb766466d58358c