### PR TITLE
Switch app theme to MaterialComponents

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.RobotIdeParkour" parent="Theme.AppCompat.NoActionBar">
+    <style name="Theme.RobotIdeParkour" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/accent_blue</item>
+        <item name="colorPrimaryVariant">@color/background_secondary</item>
+        <item name="colorOnPrimary">@color/hud_text</item>
+        <item name="colorSecondary">@color/accent_green</item>
+        <item name="colorSecondaryVariant">@color/accent_green</item>
+        <item name="colorOnSecondary">@color/hud_text</item>
         <item name="android:windowBackground">@color/background_primary</item>
         <item name="android:colorBackground">@color/background_primary</item>
         <item name="android:statusBarColor">@color/background_secondary</item>


### PR DESCRIPTION
## Summary
- update Theme.RobotIdeParkour to extend the MaterialComponents DayNight NoActionBar theme
- define primary and secondary color tokens required by Material widgets

## Testing
- ./gradlew assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e3e28b9083308c440bcbe0ced39c