### PR TITLE
Ensure world select overlay uses MaterialComponents theme

### DIFF
--- a/app/src/main/java/com/example/robotparkour/scene/WorldSelectScene.java
+++ b/app/src/main/java/com/example/robotparkour/scene/WorldSelectScene.java
@@ -4,6 +4,7 @@ package com.example.robotparkour.scene;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.view.ContextThemeWrapper;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -76,7 +77,8 @@ public class WorldSelectScene implements Scene {
         this.appContext = context.getApplicationContext();
         this.sceneManager = sceneManager;
         this.completionTracker = completionTracker;
-        this.inflater = LayoutInflater.from(context);
+        Context overlayContext = new ContextThemeWrapper(context, R.style.Theme_RobotIdeParkour);
+        this.inflater = LayoutInflater.from(overlayContext);
         reloadLevels();
     }
 


### PR DESCRIPTION
## Summary
- wrap the world select overlay inflater with a MaterialComponents-themed context so MaterialButton inflates correctly

## Testing
- ./gradlew :app:compileDebugJavaWithJavac *(fails: Android SDK not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e51b5514833093b8e024ddf176d0