### PR TITLE
Fix world selector page layout for ViewPager2

### DIFF
--- a/app/src/main/res/layout/item_level_page.xml
+++ b/app/src/main/res/layout/item_level_page.xml
@@ -2,7 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:layout_marginBottom="8dp"
     app:cardBackgroundColor="@android:color/transparent"
     app:cardElevation="0dp">
@@ -10,7 +10,7 @@
     <GridLayout
         android:id="@+id/level_grid"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:columnCount="2"
         android:orientation="horizontal" />
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary
- ensure the world selector page layout fills the ViewPager2 viewport to prevent runtime crashes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e7d0be1883309d352b9334090c9d