### PR TITLE
Add multi-page world select with per-world scoreboards

### DIFF
--- a/app/src/main/java/com/crobot/game/level/LevelCatalog.java
+++ b/app/src/main/java/com/crobot/game/level/LevelCatalog.java
@@ -13,10 +13,8 @@ import com.example.robotparkour.level.DynamicLevelGenerator;
 import com.example.robotparkour.level.LevelLibrary;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -26,6 +24,17 @@ import java.util.Locale;
 public final class LevelCatalog {
 
     private static final long MUSIC_LENGTH_THRESHOLD_BYTES = 160_000L;
+    private static final String[] ORDERED_TRACKS = new String[] {
+            "background",
+            "pointer_plains",
+            "lambda_gardens",
+            "namespace_nebula",
+            "template_temple",
+            "multithread_foundry",
+            "exception_volcano",
+            "heap_caverns",
+            "boss_fight"
+    };
 
     private static final Object LOCK = new Object();
     @Nullable
@@ -85,33 +94,16 @@ public final class LevelCatalog {
     private List<LevelDescriptor> loadDescriptors() {
         List<LevelDescriptor> list = new ArrayList<>();
         Resources resources = appContext.getResources();
-        Field[] fields = R.raw.class.getDeclaredFields();
-        List<Field> musicFields = new ArrayList<>();
-        for (Field field : fields) {
-            if (field.getType() != int.class) {
-                continue;
-            }
-            field.setAccessible(true);
-            int resId;
-            try {
-                resId = field.getInt(null);
-            } catch (IllegalAccessException ex) {
-                continue;
-            }
-            if (isMusicResource(resources, resId)) {
-                musicFields.add(field);
-            }
-        }
-        musicFields.sort(Comparator.comparing(Field::getName));
+        String packageName = appContext.getPackageName();
         int worldNumber = 1;
-        for (Field field : musicFields) {
-            int resId;
-            try {
-                resId = field.getInt(null);
-            } catch (IllegalAccessException ex) {
+        for (String entryName : ORDERED_TRACKS) {
+            int resId = resources.getIdentifier(entryName, "raw", packageName);
+            if (resId == 0) {
                 continue;
             }
-            String entryName = resources.getResourceEntryName(resId);
+            if (!isMusicResource(resources, resId)) {
+                continue;
+            }
             String displayName = toDisplayName(entryName);
             String description = buildDescription(entryName);
             WorldInfo worldInfo = new WorldInfo(worldNumber, displayName, description);

--- a/app/src/main/java/com/example/robotparkour/core/SceneManager.java
+++ b/app/src/main/java/com/example/robotparkour/core/SceneManager.java
@@ -150,7 +150,10 @@ public class SceneManager {
 
     public void showGameOver(GameResult result) {
         if (result != null && result.isVictory()) {
-            scoreboardManager.submitTime(result.getTimeSeconds());
+            WorldInfo world = selectedWorld;
+            if (world != null) {
+                scoreboardManager.submitTime(world.getProgramNumber(), result.getTimeSeconds());
+            }
         }
         if (gameOverScene != null) {
             gameOverScene.setResult(result);

--- a/app/src/main/java/com/example/robotparkour/scene/MenuScene.java
+++ b/app/src/main/java/com/example/robotparkour/scene/MenuScene.java
@@ -10,6 +10,7 @@ import android.graphics.RectF;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import com.example.robotparkour.R;
 import com.example.robotparkour.core.Scene;
 import com.example.robotparkour.core.SceneManager;
 import com.example.robotparkour.core.SceneType;
@@ -71,6 +72,7 @@ public class MenuScene implements Scene {
 
     @Override
     public void onEnter() {
+        sceneManager.getAudioManager().setMusicTrack(R.raw.robot_cpp);
         sceneManager.getAudioManager().startMusic();
         resetStory();
     }

--- a/app/src/main/res/drawable/bg_final_boss_button_active.xml
+++ b/app/src/main/res/drawable/bg_final_boss_button_active.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="20dp" />
+    <gradient
+        android:startColor="#670000"
+        android:endColor="#2C0000"
+        android:angle="90" />
+    <stroke
+        android:width="2dp"
+        android:color="#FF8888" />
+    <padding
+        android:left="2dp"
+        android:top="2dp"
+        android:right="2dp"
+        android:bottom="2dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_final_boss_button_default.xml
+++ b/app/src/main/res/drawable/bg_final_boss_button_default.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="20dp" />
+    <gradient
+        android:startColor="#3D0000"
+        android:endColor="#100000"
+        android:angle="90" />
+    <stroke
+        android:width="2dp"
+        android:color="#FF5555" />
+</shape>

--- a/app/src/main/res/drawable/bg_final_boss_button_pressed.xml
+++ b/app/src/main/res/drawable/bg_final_boss_button_pressed.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="20dp" />
+    <gradient
+        android:startColor="#5A0A0A"
+        android:endColor="#220000"
+        android:angle="90" />
+    <stroke
+        android:width="2dp"
+        android:color="#FF7777" />
+</shape>

--- a/app/src/main/res/drawable/bg_final_boss_button_selector.xml
+++ b/app/src/main/res/drawable/bg_final_boss_button_selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:drawable="@drawable/bg_final_boss_button_pressed" />
+    <item android:state_activated="true" android:drawable="@drawable/bg_final_boss_button_active" />
+    <item android:drawable="@drawable/bg_final_boss_button_default" />
+</selector>

--- a/app/src/main/res/layout/view_world_select_pager.xml
+++ b/app/src/main/res/layout/view_world_select_pager.xml
@@ -67,23 +67,7 @@
                 app:icon="@drawable/ic_chevron_left"
                 app:iconPadding="0dp"
                 app:iconTint="@android:color/white"
-                android:text="Zurück"
-                android:textColor="@android:color/white" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_next"
-                style="@style/Widget.MaterialComponents.Button.TextButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:minWidth="0dp"
-                android:minHeight="0dp"
-                android:padding="12dp"
-                app:cornerRadius="24dp"
-                app:icon="@drawable/ic_chevron_right"
-                app:iconPadding="0dp"
-                app:iconTint="@android:color/white"
-                android:text="Weiter"
+                android:text="@string/world_select_back_to_menu"
                 android:textColor="@android:color/white" />
 
             <View
@@ -92,14 +76,19 @@
                 android:layout_weight="1" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_close"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:id="@+id/button_next"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Zur Karte"
-                android:textColor="@android:color/white"
-                app:strokeColor="@android:color/white"
-                app:strokeWidth="1dp" />
+                android:minWidth="0dp"
+                android:minHeight="0dp"
+                android:padding="12dp"
+                app:cornerRadius="24dp"
+                app:icon="@drawable/ic_chevron_right"
+                app:iconPadding="0dp"
+                app:iconTint="@android:color/white"
+                android:text="@string/world_select_page_two"
+                android:textColor="@android:color/white" />
         </LinearLayout>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">Robot IDE Parkour</string>
+    <string name="world_select_best_time">Bestzeit: %1$s</string>
+    <string name="world_select_best_time_placeholder">Bestzeit: —</string>
+    <string name="world_select_page_two">2. Seite</string>
+    <string name="world_select_page_three">3. Seite</string>
+    <string name="world_select_back">Back</string>
+    <string name="world_select_back_to_menu">Back</string>
 </resources>


### PR DESCRIPTION
## Summary
- curate the level catalog order so nine campaign stages lead up to the boss while keeping the menu track separate
- persist best times per world and surface them in both the scoreboard scene and each world selection tile
- redesign the world selection overlay with paged navigation, robot_cpp menu music, and a styled final boss button

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ec05291c8330917160e85b5b88cd