### PR TITLE
Fix enemy animation creation without view context

### DIFF
--- a/app/src/main/java/com/crobot/game/GameView.java
+++ b/app/src/main/java/com/crobot/game/GameView.java
@@ -385,8 +385,9 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
             if (kind == null) {
                 continue;
             }
+            AnimatedEnemy animatedSprite = EnemyAnimations.create(kind.typeName);
             EnemyInstance instance = new EnemyInstance(kind, entity.getX(), entity.getY(),
-                    tileWidth, tileHeight, entity.getExtras());
+                    tileWidth, tileHeight, entity.getExtras(), animatedSprite);
             if (instance.kind == EnemyKind.PACKET_HOUND && !isBossWorld) {
                 continue;
             }
@@ -3075,7 +3076,8 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
                       float pixelY,
                       float tileWidth,
                       float tileHeight,
-                      @Nullable Map<String, String> extras) {
+                      @Nullable Map<String, String> extras,
+                      @Nullable AnimatedEnemy animatedSprite) {
             this.kind = kind;
             this.tileWidth = tileWidth;
             this.tileHeight = tileHeight;
@@ -3100,7 +3102,7 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
             this.leaderId = this.extras.get("leader");
             this.channel = this.extras.get("channel");
             this.trigger = this.extras.get("trigger");
-            this.animatedSprite = EnemyAnimations.create(kind.typeName);
+            this.animatedSprite = animatedSprite;
         }
 
         @NonNull


### PR DESCRIPTION
## Summary
- create enemy animations in GameView before instantiating EnemyInstance to avoid static context access
- pass the prepared AnimatedEnemy into the EnemyInstance constructor instead of calling getContext from the static inner class

## Testing
- Not run (Android SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68da3dc2757483308272180ebbe98129