### PR TITLE
Fix enemy animation factory usage in GameView

### DIFF
--- a/app/src/main/java/com/crobot/game/GameView.java
+++ b/app/src/main/java/com/crobot/game/GameView.java
@@ -385,7 +385,7 @@ public class GameView extends SurfaceView implements SurfaceHolder.Callback, Run
             if (kind == null) {
                 continue;
             }
-            AnimatedEnemy animatedSprite = EnemyAnimations.create(kind.typeName);
+            AnimatedEnemy animatedSprite = EnemyAnimations.create(getContext(), kind.typeName);
             EnemyInstance instance = new EnemyInstance(kind, entity.getX(), entity.getY(),
                     tileWidth, tileHeight, entity.getExtras(), animatedSprite);
             if (instance.kind == EnemyKind.PACKET_HOUND && !isBossWorld) {


### PR DESCRIPTION
## Summary
- pass the GameView context into EnemyAnimations.create so sprites requiring resources are built correctly

## Testing
- ./gradlew :app:compileDebugJavaWithJavac *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da54f24d088330bd4946e5d767ef71